### PR TITLE
Add Machine Type Support

### DIFF
--- a/pkg/cloudprovider/provider/vultr/types/types.go
+++ b/pkg/cloudprovider/provider/vultr/types/types.go
@@ -34,3 +34,10 @@ func GetConfig(pconfig providerconfigtypes.Config) (*RawConfig, error) {
 
 	return rawConfig, jsonutil.StrictUnmarshal(pconfig.CloudProviderSpec.Raw, rawConfig)
 }
+
+type MachineType string
+
+const (
+	BareMetal     MachineType = "bare-metal"
+	CloudInstance MachineType = "cloud-instance"
+)

--- a/test/e2e/provisioning/testdata/machinedeployment-vultr-baremetal.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vultr-baremetal.yaml
@@ -1,0 +1,39 @@
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineDeployment
+metadata:
+  name: << MACHINE_NAME >>
+  namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      name: << MACHINE_NAME >>
+  template:
+    metadata:
+      labels:
+        name: << MACHINE_NAME >>
+    spec:
+      providerSpec:
+        value:
+          sshPublicKeys:
+            - "<< YOUR_PUBLIC_KEY >>"
+          cloudProvider: "vultr"
+          cloudProviderSpec:
+            apiKey: << VULTR_API_KEY >>
+            region: blr
+            plan: 'vhf-8c-32gb'
+            osId: 127
+            machineType: 'bare-metal'
+          operatingSystem: "<< OS_NAME >>"
+          operatingSystemSpec:
+            distUpgradeOnBoot: false
+            disableAutoUpdate: true
+      versions:
+        kubelet: "<< KUBERNETES_VERSION >>"


### PR DESCRIPTION
## What does this PR do?

This PR adds optional support for the `MachineType` property in the Vultr provider spec, which enables creating a `BareMetalServer` instead of a cloud instance from Vultr.

This is based on reference from multiple stale branches from the AtomicJar fork where we implemented our own Vultr support... the most recent one being here: https://github.com/kubermatic/machine-controller/compare/main...AtomicJar:machine-controller:implement-vultr-cloud-provider

At this time, this PR is internal to the `aj-main` root branch, which is the forked publishing branch and is for internal testing. A cherry-picked version will be created for kubermatic at a later date.

## Why is it important?

We use bare metal servers with AJ TCC deployments, and this will enable us to use them with the upstream Vultr support, instead of our own forked version which is known to have bugs.

## Remaining Tasks
- [ ] Testing