### PR TITLE
Support Machine ID on Machine provider status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+on:
+  push:
+    branches: [ aj-main ]
+  pull_request:
+    branches: [ aj-main ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # depth 0 makes the whole history checked out, and without it the build and tests differ, because default
+          # depth of 1 might easily fetch a non-tagged commit, hence the version isn't semantic but commit has only
+          fetch-depth: 0
+      - name: Print version tag
+        run: git describe --tags --dirty=-dirty --always
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          cache-dependency-path: go.sum
+          go-version-file: go.mod
+      - name: Run unit tests
+        run: make test-unit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Publish
+run-name: Publishing "${{ github.event.workflow_run.head_commit.message }}"
+
+on:
+  workflow_run:
+    workflows: [CI]
+    branches: [aj-main]
+    types: [completed]
+
+jobs:
+  on-success:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - run: echo 'The triggering workflow passed'
+  on-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'The triggering workflow failed'
+  publish:
+    runs-on: ubuntu-latest
+    needs: [ on-success ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Print version tag
+        run: git describe --tags --dirty=-dirty --always
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          cache-dependency-path: go.sum
+          go-version-file: go.mod
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - name: Publish image
+        run: make docker-image-publish
+        env:
+          IMAGE_NAME: "atomicjar/machine-controller:${{ github.event.workflow_run.head_commit.id }}"
+          IMAGE_TAG: ${{ github.event.workflow_run.head_commit.id }}
+

--- a/pkg/cloudprovider/provider/vultr/types/types.go
+++ b/pkg/cloudprovider/provider/vultr/types/types.go
@@ -29,6 +29,10 @@ type RawConfig struct {
 	Tags   []string                            `json:"tags,omitempty"`
 }
 
+type ProviderStatus struct {
+	VultrId string `json:"vultrId"`
+}
+
 func GetConfig(pconfig providerconfigtypes.Config) (*RawConfig, error) {
 	rawConfig := &RawConfig{}
 

--- a/pkg/cloudprovider/provider/vultr/types/types.go
+++ b/pkg/cloudprovider/provider/vultr/types/types.go
@@ -34,3 +34,10 @@ func GetConfig(pconfig providerconfigtypes.Config) (*RawConfig, error) {
 
 	return rawConfig, jsonutil.StrictUnmarshal(pconfig.CloudProviderSpec.Raw, rawConfig)
 }
+
+type MachineType string
+
+const (
+	BareMetal     MachineType = "bare-metal"
+	CloudInstance MachineType = "cloud-instance"
+)

--- a/test/e2e/provisioning/testdata/machinedeployment-vultr-baremetal.yaml
+++ b/test/e2e/provisioning/testdata/machinedeployment-vultr-baremetal.yaml
@@ -1,0 +1,39 @@
+apiVersion: "cluster.k8s.io/v1alpha1"
+kind: MachineDeployment
+metadata:
+  name: << MACHINE_NAME >>
+  namespace: kube-system
+  annotations:
+    k8c.io/operating-system-profile: osp-<< OS_NAME >>
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      name: << MACHINE_NAME >>
+  template:
+    metadata:
+      labels:
+        name: << MACHINE_NAME >>
+    spec:
+      providerSpec:
+        value:
+          sshPublicKeys:
+            - "<< YOUR_PUBLIC_KEY >>"
+          cloudProvider: "vultr"
+          cloudProviderSpec:
+            apiKey: << VULTR_API_KEY >>
+            region: blr
+            plan: 'vhf-8c-32gb'
+            osId: 127
+            machineType: 'bare-metal'
+          operatingSystem: "<< OS_NAME >>"
+          operatingSystemSpec:
+            distUpgradeOnBoot: false
+            disableAutoUpdate: true
+      versions:
+        kubelet: "<< KUBERNETES_VERSION >>"


### PR DESCRIPTION
# What does this PR do?
This PR moves tracking of the relationship between "machine" <--> "Vultr instance/server" out of Vultr tags by default, and into the Machine provider status, while still falling back to tags if the provider status is unset

# Why is it important?
Vultr tags have been shown to be eventually consistent, which has resulted in duplicate Vultr nodes being associated with a single machine, which creates a variety of serious problems in clusters.

This pushes the Id into the machine configuration within the K8S kubelet, which is atomic and referentially consistent.

# Remaining Work
- [ ] Need to handle instance-not-found properly
- [ ] Testing